### PR TITLE
Expand

### DIFF
--- a/sp-rest-api.js
+++ b/sp-rest-api.js
@@ -235,7 +235,7 @@ SpRestApi.appendSelectQueryString = function (url, select) {
  *      May contain other query string parameters.
  * @param {string|Array.<string>} filters - Which columns to select from a
  *      list (instead of fetching all columns).
- * @returns {string} An URL with a string lie "...?$Filter=Title eq 'Test'".
+ * @returns {string} An URL with a string like "...?$Filter=Title eq 'Test'".
  */
 SpRestApi.appendFilters = function (url, filters) {
     if (!filters) { return url; }
@@ -264,7 +264,7 @@ SpRestApi.appendFilters = function (url, filters) {
  * @param {string} url - The base URL to which we need to append the string.
  *      May contain other query string parameters.
  * @param {string|Array.<string>} expand - Which columns to expand
- * @returns {string} An URL with a string lie "...?$Filter=Title eq 'Test'".
+ * @returns {string} An URL with a string like "...?$expand=LookupField".
  */
 SpRestApi.appendExpand = function (url, expand) {
     if (!expand) { return url; }

--- a/sp-rest-api.js
+++ b/sp-rest-api.js
@@ -390,6 +390,8 @@ SpRestApi.prototype.getItem = function (itemId) {
 
     var url = this.options.siteUrl +
         this.options.urls.item.format(this.options.listTitle, itemId);
+    url = SpRestApi.appendSelectQueryString(url, this.options.select);
+    url = SpRestApi.appendExpand(url,this.options.expand);
     this.loadUrl(url, 'GET', this.options.onsuccess, this.options.onerror);
 };
 

--- a/sp-rest-api.js
+++ b/sp-rest-api.js
@@ -188,6 +188,7 @@ SpRestApi.prototype.generateGetAllListItemsUrl = function () {
     url = this.addMaxItems(url);
     url = SpRestApi.appendSelectQueryString(url, this.options.select);
     url = SpRestApi.appendFilters(url, this.options.filters);
+    url = SpRestApi.appendExpand(url,this.options.expand);
 
     return url;
 };
@@ -202,6 +203,7 @@ SpRestApi.prototype.generateSingleListItemUrl = function (itemId) {
         this.options.urls.item.format(this.options.listTitle, itemId);
 
     url = SpRestApi.appendSelectQueryString(url, this.options.select);
+    url = SpRestApi.appendExpand(url,this.options.expand);
 
     return url;
 };
@@ -256,6 +258,36 @@ SpRestApi.appendFilters = function (url, filters) {
 
     return url + separator + '$filter=' + filters;
 };
+
+/**
+ * Appends the $filter query string to the SharePoint REST API URL.
+ * @param {string} url - The base URL to which we need to append the string.
+ *      May contain other query string parameters.
+ * @param {string|Array.<string>} expand - Which columns to expand
+ * @returns {string} An URL with a string lie "...?$Filter=Title eq 'Test'".
+ */
+SpRestApi.appendExpand = function (url, expand) {
+    if (!expand) { return url; }
+    
+    if (expand instanceof Array) {
+        // Remove empty values: 
+        expand = SpRestApi.compactArray(expand);
+
+        // Enclose each item in brackets and concatenate with 'AND':
+        expand.forEach(function (expand, i) {
+            expand[i] = '(' + expand + ')';
+        });
+
+        // Concatenate filters with AND condition
+        expand = expand.join(',');
+    }
+
+    // Decide whether to use ? or & for separating query string params
+    var separator = url.includes('?') ? '&' : '?';
+
+    return url + separator + '$expand=' + expand;
+}
+
 
 /**
  * Returns all list items from a subfolder of a SharePoint list. Uses a hacky


### PR DESCRIPTION
The expand option did not appear to be implemented.  Updates for getAllItems and getItem.
Requires column to explicitly be in a select. `.config({expand:['Role'], select:'Title,Role/Title'})`